### PR TITLE
docs: SEO pass and automated Algolia reindex on deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 .idea
 .docusaurus
 build
+
+# Local Netlify folder
+.netlify

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -92,9 +92,9 @@ We've prepared comprehensive migration guides to help you upgrade smoothly:
 
 Before becoming Suites at `v3.0.0`, the project was developed as **Automock** from `v1.0.0` through `v2.x`. During this period, the foundational architecture was established:
 
-- **`v2.1.0`** (Dec 2023) — InversifyJS adapter support
-- **`v2.0.0`** (Nov 2022) — Native mocking implementation, Node.js v16+ requirement
-- **`v1.x series`** (2022) — Property injection support, enhanced dependency resolution
+- **`v2.1.0`** (Dec 2023): InversifyJS adapter support
+- **`v2.0.0`** (Nov 2022): Native mocking implementation, Node.js v16+ requirement
+- **`v1.x series`** (2022): Property injection support, enhanced dependency resolution
 
 The transition to Suites represented a rebranding and modernization while preserving the core testing philosophy and architectural foundations built during the Automock era.
 

--- a/docs/guides/test-doubles.md
+++ b/docs/guides/test-doubles.md
@@ -1,48 +1,67 @@
 ---
 sidebar_position: 2
-title: Test Doubles (Mocks & Stubs)
-description: Understanding test doubles in Suites like mocks and stubs
+title: "Test Doubles in TypeScript: Mocks, Stubs, Spies, Fakes Explained"
+description: Test doubles are stand-ins for real dependencies in unit tests. This guide explains mocks, stubs, spies, and fakes, with TypeScript examples using Suites.
+keywords: [ test doubles, mocks, stubs, spies, fakes, mocks vs stubs, typescript testing, unit testing, martin fowler test doubles ]
 ---
 
-# Mocks and Stubs
+# Test Doubles: Mocks, Stubs, Spies, and Fakes
 
-> **What this covers:** Understanding mocks, stubs, and other test doubles \
+> **What this covers:** What test doubles are, the four main types, when to use each, and how Suites generates them
+> automatically for TypeScript backends. \
 > **Time to read:** ~10 minutes \
-> **Prerequisites:** [Unit Testing Fundamentals](/docs/guides/fundamentals) \
+> **Prerequisites:** Familiarity with unit testing concepts. New to Suites? Start with
+> the [Quickstart](/docs/get-started/quickstart). \
 > **Best for:** Understanding the theory behind test doubles after hands-on experience with solitary testing
 
-When you write unit tests, you need to replace real dependencies with fake versions you can control. These fake versions are called **test doubles**. This guide explains the different types of test doubles, with a focus on **mocks** and **stubs**, and shows you how Suites automatically create them for you.
+A **test double** is a stand-in object you use in a unit test in place of a real dependency (a database, an HTTP client,
+a third-party SDK), so the test stays fast, deterministic, and isolated from the outside world.
 
-## Overview
+The term comes from [Gerard Meszaros's _xUnit Test Patterns_](http://xunitpatterns.com/Test%20Double.html) and was
+popularised by [Martin Fowler's "Mocks Aren't Stubs"](https://martinfowler.com/articles/mocksArentStubs.html). Both
+works distinguish four common kinds of test double:
 
-This guide covers:
+| Type     | What it does                                                          | Typical use                                                                             |
+|----------|-----------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
+| **Stub** | Returns a hard-coded value when called. No verification.              | Make a dependency return what your test needs.                                          |
+| **Mock** | Records calls so the test can assert *how* the dependency was used.   | Verify the system-under-test called `repo.save()` exactly once with the right argument. |
+| **Spy**  | Wraps a real object, records calls, but lets the real method execute. | Observe behaviour without changing it.                                                  |
+| **Fake** | A working but simplified implementation (e.g. in-memory database).    | When the real dependency is too heavy but a stub would lose too much realism.           |
 
-1. What test doubles are and the common types
-2. How Suites uses the terms "mocks" and "stubs"
-3. Why some dependencies can be replaced and others cannot
-4. Two ways to verify your tests work correctly
-5. How Suites automatically generates mocks for you
-6. When to use real implementations instead of test doubles
+The distinction that catches most people out: a **stub** answers *queries*, a **mock** verifies *commands*. Fowler calls
+this _state verification_ vs _behaviour verification_. If you're unsure which you need, you almost always want a stub.
 
-## What Are Test Doubles?
+## Why test doubles matter
 
-A **test double** is a fake version of a dependency that you use in your tests. Think of it like a stunt double in a movie - it stands in for the real thing so you can control what happens.
+Without them, a "unit" test ends up exercising your entire dependency tree: the database, the network, the file system.
+The result is slow, flaky, and tells you very little about the unit you actually changed. Test doubles let you isolate
+one piece of code, make its environment deterministic, and assert on it precisely.
 
-Test doubles help you:
-- Control what your dependencies return
-- Isolate the code you want to test
-- Avoid side effects like database writes or API calls
+## Test doubles in Suites
 
-**Common types of test doubles:**
+Writing test doubles by hand is repetitive: for every dependency, you build a fake class, stub each method, wire it into
+your DI container. Suites does this automatically. Given a class with constructor-injected dependencies, Suites
+generates a fully-mocked version of every dependency, no manual `jest.fn()` calls, no hand-rolled fakes.
 
-- **Stub**: Returns a predetermined response when called
-- **Mock**: A fake class where you can verify method calls
-- **Spy**: Records information about how it was called (wraps the real object)
-- **Fake**: A simplified working version (like an in-memory database)
+```typescript
+import { TestBed, Mocked } from '@suites/unit';
 
-:::info
-Suites follows [Martin Fowler's test double patterns](https://martinfowler.com/bliki/TestDouble.html), using the vocabulary from Gerard Meszaros's xUnit Test Patterns.
-:::
+const { unit, unitRef } = await TestBed.solitary(UserService).compile();
+const repo: Mocked<UserRepository> = unitRef.get(UserRepository);
+
+repo.findById.mockResolvedValue(testUser);  // stub a return value
+await unit.activateUser('123');
+expect(repo.save).toHaveBeenCalledWith(testUser);  // verify a call
+```
+
+That's it - `UserRepository` was generated as a mock with every method pre-stubbed. No setup file, no manual mock
+factory.
+
+> **Try it:** Set up Suites and write your first test in under five minutes. See
+> the [Quickstart](/docs/get-started/quickstart).
+
+The rest of this guide explains how Suites uses the terms _mock_ and _stub_, which dependencies it can and can't
+replace, and how to choose between state and behaviour verification in practice.
 
 ## How Suites Uses "Mocks" and "Stubs"
 
@@ -63,11 +82,14 @@ repo.findById.mockResolvedValue(testUser);
 // findById is now a stub that returns testUser
 ```
 
-**Simple rule:** When you see `Mocked<UserRepository>`, it means you have a mock (fake class) where all methods are stubs (fake methods).
+**Simple rule:** When you see `Mocked<UserRepository>`, it means you have a mock (fake class) where all methods are
+stubs (fake methods).
 
 ## Dependencies: What Can Be Replaced?
 
-Suites can only create test doubles for **explicit dependencies** - dependencies that are passed in through the constructor or method parameters. It cannot replace **implicit dependencies** - things that are imported directly at the top of a file.
+Suites can only create test doubles for **explicit dependencies** - dependencies that are passed in through the
+constructor or method parameters. It cannot replace **implicit dependencies** - things that are imported directly at the
+top of a file.
 
 **Explicit dependencies** (Suites can replace these):
 
@@ -84,12 +106,12 @@ export class UserService {
 **Implicit dependencies** (Suites cannot replace these):
 
 ```typescript
-import { sendEmail } from './email-utils';  // ❌ Direct import
+import { sendEmail } from './email-utils'; // ❌ Direct import
 
 @Injectable()
 export class UserService {
   createUser(data: UserData) {
-    sendEmail(data.email);  // ❌ Always runs the real code
+    sendEmail(data.email); // ❌ Always runs the real code
   }
 }
 ```
@@ -135,7 +157,7 @@ Suites automatically creates mocks for all dependencies.
 
 ```typescript
 const { unit, unitRef } = await TestBed.solitary(UserService).compile();
-const repo = unitRef.get(UserRepository);  // Automatically a mock!
+const repo = unitRef.get(UserRepository); // Automatically a mock!
 
 // Now configure what the stub methods should return
 repo.findById.mockResolvedValue(testUser);
@@ -149,7 +171,8 @@ For more details on configuration options, see:
 
 ## Testing with Real Implementations
 
-Sometimes you want to test how multiple components work together using real code, not mocks. Use sociable tests for this:
+Sometimes you want to test how multiple components work together using real code, not mocks. Use sociable tests for
+this:
 
 ```typescript
 const { unit } = await TestBed.sociable(UserService)
@@ -167,14 +190,14 @@ See [Sociable Unit Tests](/docs/guides/sociable) for more information.
 
 ### Quick Reference
 
-| Term                    | What It Means                                                | Example                                 |
-|-------------------------|--------------------------------------------------------------|-----------------------------------------|
-| **Test Double**         | Any fake replacement for a real dependency                   | Any mock, stub, spy, fake, or dummy     |
-| **Mock**                | A fake version of an entire class (all methods are stubs)    | `Mocked<UserRepository>`                |
-| **Stub**                | A fake method that returns a predetermined value             | `repo.findById.mockResolvedValue(user)` |
-| **Spy**                 | A stub that also records how it was called                   | `jest.spyOn()` - not recommended        |
-| **Explicit Dependency** | Passed in through constructor or parameters                  | `constructor(private db: Database)`     |
-| **Implicit Dependency** | Imported directly at the top of the file                     | `import { sendEmail } from './utils'`   |
+| Term                    | What It Means                                             | Example                                 |
+|-------------------------|-----------------------------------------------------------|-----------------------------------------|
+| **Test Double**         | Any fake replacement for a real dependency                | Any mock, stub, spy, fake, or dummy     |
+| **Mock**                | A fake version of an entire class (all methods are stubs) | `Mocked<UserRepository>`                |
+| **Stub**                | A fake method that returns a predetermined value          | `repo.findById.mockResolvedValue(user)` |
+| **Spy**                 | A stub that also records how it was called                | `jest.spyOn()` - not recommended        |
+| **Explicit Dependency** | Passed in through constructor or parameters               | `constructor(private db: Database)`     |
+| **Implicit Dependency** | Imported directly at the top of the file                  | `import { sendEmail } from './utils'`   |
 
 ### Takeaways
 
@@ -193,4 +216,5 @@ Learn more about using test doubles in practice:
 
 ## Additional Resources
 
-- **[Martin Fowler - Mocks Aren't Stubs](https://martinfowler.com/articles/mocksArentStubs.html)**: Classic article explaining different testing approaches
+- **[Martin Fowler - Mocks Aren't Stubs](https://martinfowler.com/articles/mocksArentStubs.html)**: Classic article
+  explaining different testing approaches

--- a/docs/guides/test-doubles.md
+++ b/docs/guides/test-doubles.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 2
-title: "Test Doubles in TypeScript: Mocks, Stubs, Spies, Fakes Explained"
+title: "Test Doubles in Suites: Mocks, Stubs, Spies, Fakes Explained"
 description: Test doubles are stand-ins for real dependencies in unit tests. This guide explains mocks, stubs, spies, and fakes, with TypeScript examples using Suites.
 keywords: [ test doubles, mocks, stubs, spies, fakes, mocks vs stubs, typescript testing, unit testing, martin fowler test doubles ]
 ---

--- a/docs/migration-guides/from-automock.md
+++ b/docs/migration-guides/from-automock.md
@@ -1,15 +1,16 @@
 ---
 sidebar_position: 5
-title: Migrating from Automock
-description: Step-by-step guide to migrate from Automock to Suites. Covers dependency updates, API changes, and new features in v3.
+title: "Migrating from Automock to Suites"
+description: How to migrate from @automock/jest and @automock/sinon to Suites. Covers package renames, the TestBed API change, and the new solitary and sociable test types.
+keywords: [ automock, migrate from automock, automock to suites, "@automock/jest", "@automock/sinon", testbedbuilder, suites migration ]
 ---
 
 # Migrating from Automock to Suites
 
 ## Introduction
 
-Suites succeeds Automock as the actively developed testing framework. Automock stopped at version `2.1.0` and receives
-critical fixes only. All new development continues in Suites, starting from version In `3.0.0`.
+Suites succeeds Automock as the actively developed testing framework. Automock stopped at version `2.1.2` and receives
+critical fixes only. All new development continues in Suites, starting from version `3.0.0`.
 
 This guide covers the migration process from Automock to Suites, including dependency updates, API changes, and new
 features.
@@ -18,13 +19,29 @@ For detailed setup instructions, see the [Installation Guide](/docs/get-started/
 
 ## The Shift from Automock
 
-Version `3.0.0` of Suites was the first release after Automock's `v2.1.0` completion, with subsequent improvements in `3.0.1` and beyond. Each new version comes with more features
-and better support. Automock will continue to receive critical fixes for version `v2.1.0`, but all new development will focus on Suites.
+Version `3.0.0` of Suites was the first release after Automock's `v2.1.2` completion, with subsequent improvements in
+`3.0.1` and beyond. Each new version comes with more features
+and better support. Automock will continue to receive critical fixes for `v2.1.x`, but all new development will focus on
+Suites.
 
 ## Migration Guide
 
-:::info
-**Automated Migration:** Codemods to automate the migration process are under development and planned for release in Q1 2025.
+:::tip Recommended: run the codemod
+The [`@suites/codemod`](https://github.com/suites-dev/codemod) package automates almost everything in this guide: it
+rewrites imports, converts `TestBed.create()` to `await TestBed.solitary().compile()`, picks between `.impl()` and
+`.final()` for each mock, switches `jest.Mocked<T>` to `Mocked<T>`, and adds `async`/`await` to test hooks where needed.
+
+```bash
+# Preview the changes first (no files written)
+npx @suites/codemod automock/2/to-suites-v3 'src/**/*.spec.ts' --dry
+
+# Apply
+npx @suites/codemod automock/2/to-suites-v3 'src/**/*.spec.ts'
+```
+
+After running, you still need to [update your dependencies](#step-1-update-dependencies) (the codemod only rewrites
+code, not `package.json`). The remaining steps below describe what the codemod does, in case you want to migrate
+manually or understand a specific transformation.
 :::
 
 ### Step 1: Update Dependencies
@@ -40,13 +57,23 @@ npm uninstall @automock/jest @automock/sinon
 # Install Suites core
 npm install --save-dev @suites/unit
 
-# Install adapters based on your setup
+# Then install adapters for your stack:
+
+# NestJS + Jest
 npm install --save-dev @suites/doubles.jest @suites/di.nestjs
-# OR
-npm install --save-dev @suites/doubles.sinon @suites/di.inversify
-# OR
+
+# NestJS + Vitest
 npm install --save-dev @suites/doubles.vitest @suites/di.nestjs
+
+# NestJS + Sinon
+npm install --save-dev @suites/doubles.sinon @suites/di.nestjs
+
+# InversifyJS + Sinon
+npm install --save-dev @suites/doubles.sinon @suites/di.inversify
 ```
+
+Suites splits the doubles library and the DI integration into separate packages, so install one `@suites/doubles.*` and
+one `@suites/di.*` matching your stack.
 
 ### Step 2: Update Imports
 
@@ -69,14 +96,14 @@ Update TestBed API calls to match the new syntax. The `beforeAll` or `beforeEach
 ```typescript
 // Before
 beforeAll(() => {
-  const { unit } = TestBed.create(Service).compile();
+  const {unit} = TestBed.create(Service).compile();
 });
 ```
 
 ```typescript
 // After
 beforeAll(async () => {
-  const { unit } = await TestBed.solitary(Service).compile();
+  const {unit} = await TestBed.solitary(Service).compile();
 });
 ```
 
@@ -87,34 +114,34 @@ Update any mock implementation code to use the new syntax:
 ```typescript
 // Before
 TestBed.create(UserService)
-  .mock(UserRepository)
-  .using({
-    getUserById: () => Promise.resolve({ id: 1, name: 'John' }),
-  })
-  .compile();
+.mock(UserRepository)
+.using({
+  getUserById: () => Promise.resolve({id: 1, name: 'John'}),
+})
+.compile();
 
 // After
 await TestBed.solitary(UserService)
-  .mock(UserRepository)
-  .final({
-    getUserById: () => Promise.resolve({ id: 1, name: 'John' }),
-  })
-  .compile();
+.mock(UserRepository)
+.final({
+  getUserById: () => Promise.resolve({id: 1, name: 'John'}),
+})
+.compile();
 
 // OR using .impl() for more flexibility
 await TestBed.solitary(UserService)
-  .mock(UserRepository)
-  .impl((stubFn) => ({
-    getUserById: stubFn().mockResolvedValue({ id: 1, name: 'John' }),
-  }))
-  .compile();
+.mock(UserRepository)
+.impl((stubFn) => ({
+  getUserById: stubFn().mockResolvedValue({id: 1, name: 'John'}),
+}))
+.compile();
 ```
 
 ## Major Changes from Automock to Suites
 
 ### Versioning
 
-- Automock stopped at version `2.1.0`, and will receive critical bug fixes only.
+- Automock stopped at version `2.1.2`, and will receive critical bug fixes only.
 - Suites started at version `3.0.0` and is currently at `3.0.1+`, continuing active development.
 
 ### Breaking Changes
@@ -123,23 +150,25 @@ await TestBed.solitary(UserService)
 
 ```typescript
 // Before
-const { unit } = TestBed.create(Service).compile();
+const {unit} = TestBed.create(Service).compile();
 ```
 
 ```typescript
 // After
-const { unit } = await TestBed.solitary(Service).compile();
+const {unit} = await TestBed.solitary(Service).compile();
 ```
 
-**`TestBed.create()` is now `TestBed.solitary()`**: This change supports the distinction between solitary and sociable testing approaches. See [Solitary API](/docs/api-reference/testbed-solitary).
+**`TestBed.create()` is now `TestBed.solitary()`**: This change supports the distinction between solitary and sociable
+testing approaches. See [Solitary API](/docs/api-reference/testbed-solitary).
 
-* **New `.sociable()` method**: Added to the TestBed API for testing with real implementations of select dependencies. See [Sociable API](/docs/api-reference/testbed-sociable).
+* **New `.sociable()` method**: Added to the TestBed API for testing with real implementations of select dependencies.
+  See [Sociable API](/docs/api-reference/testbed-sociable).
 
 * **Unified TestBed import**: TestBed is now exported from `@suites/unit` regardless of the installed adapters.
-Instead of importing from `@automock/jest` or `@automock/sinon`, now import from `@suites/unit`.
+  Instead of importing from `@automock/jest` or `@automock/sinon`, now import from `@suites/unit`.
 
 * **Mocked type**: The new `Mocked<T>` type from `@suites/unit` provides deep partial mock capabilities,
-allowing for deep mocks of properties within the class.
+  allowing for deep mocks of properties within the class.
 
 **API Changes in TestBed**:
 
@@ -153,14 +182,17 @@ See [Mock Configuration API](/docs/api-reference/mock-configuration) for complet
 ### New Features
 
 - **Support for Vitest and ESM**: Suites now supports Vitest and ECMAScript Modules (ESM).
-- **Sociable Unit Testing**: Test with real implementations of selected dependencies. See [Sociable Unit Tests](/docs/guides/sociable).
-- **Enhanced Type Safety**: Improved TypeScript support with the `Mocked<T>` type. See [Types API](/docs/api-reference/types).
+- **Sociable Unit Testing**: Test with real implementations of selected dependencies.
+  See [Sociable Unit Tests](/docs/guides/sociable).
+- **Enhanced Type Safety**: Improved TypeScript support with the `Mocked<T>` type.
+  See [Types API](/docs/api-reference/types).
 
 ## Troubleshooting Common Migration Issues
 
 ### Async/Await Errors
 
-Errors like `TypeError: Cannot read properties of undefined (reading 'get')` indicate missing `await` with `TestBed.solitary().compile()`.
+Errors like `TypeError: Cannot read properties of undefined (reading 'get')` indicate missing `await` with
+`TestBed.solitary().compile()`.
 
 ### Type Errors with Mocked
 
@@ -171,6 +203,7 @@ See [Types API Reference](/docs/api-reference/types) for details:
 ```typescript
 // Before
 import { UserRepository } from './user.repository';
+
 let userRepo: jest.Mocked<UserRepository>;
 ```
 
@@ -178,6 +211,7 @@ let userRepo: jest.Mocked<UserRepository>;
 // After
 import { Mocked } from '@suites/unit';
 import { UserRepository } from './user.repository';
+
 let userRepo: Mocked<UserRepository>;
 ```
 
@@ -187,8 +221,29 @@ Errors about missing dependencies indicate that adapter packages need installati
 
 See [Installation Guide](/docs/get-started/installation#supported-libraries-adapters) for the complete list of adapters.
 
+## Looking for old Automock internals?
+
+If you were depending on Automock internals rather than the public `TestBed` API, some symbols and file paths have moved
+or been renamed in Suites. The most common ones people search for:
+
+| Automock                                        | Suites                                                                                                                 |
+|-------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `@automock/jest`                                | `@suites/unit` plus `@suites/doubles.jest`                                                                             |
+| `@automock/sinon`                               | `@suites/unit` plus `@suites/doubles.sinon`                                                                            |
+| `@automock/core`                                | `@suites/core` (internal; consume the public API via `@suites/unit`)                                                   |
+| `TestBed.create(Service)`                       | `TestBed.solitary(Service)` (now `async`)                                                                              |
+| `.mock(X).using({...})`                         | `.mock(X).final({...})` or `.mock(X).impl((stub) => ({...}))`                                                          |
+| `packages/core/src/services/testbed-builder.ts` | Restructured under `@suites/core` and the DI adapters                                                                  |
+| `TestbedBuilder` (internal class)               | Split into solitary and sociable builders, kept internal                                                               |
+| `ClassCtorReflector`, `class-props-reflector`   | Reflection utilities now live inside `@suites/di.nestjs` and `@suites/di.inversify` and are not part of the public API |
+
+Recommended path: depend only on the public surface (`TestBed` from `@suites/unit` and the `Mocked<T>` type). If you
+have a use case that requires internals, please [open an issue](https://github.com/suites-dev/suites/issues) so we can
+either expose what you need or suggest an alternative.
+
 ## Historical Releases and NPM Packages
 
-The release history and NPM packages under the `@automock` scope will be preserved for historical reference. However, all new features and improvements will be released under the `@suites` scope.
+The release history and NPM packages under the `@automock` scope will be preserved for historical reference. However,
+all new features and improvements will be released under the `@suites` scope.
 
 For more information, see the [Suites release notes](https://github.com/suites-dev/suites/releases).

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -37,6 +37,7 @@ const config: Config = {
           path: "docs",
           routeBasePath: "docs",
           sidebarPath: require.resolve("./config/docs-sidebars.js"),
+          editUrl: "https://github.com/suites-dev/docs.suites.dev/edit/master/",
           remarkPlugins: [
             [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],
           ],

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,21 @@
 # ===========================================
+# BUILD
+# ===========================================
+# Triggers an Algolia DocSearch crawler reindex after every successful
+# production build. The script is a no-op for deploy previews and branch
+# deploys, and a no-op (with a warning) if crawler env vars are missing,
+# so it cannot break the build.
+#
+# Required env vars in Netlify → Site settings → Environment variables:
+#   ALGOLIA_CRAWLER_USER_ID
+#   ALGOLIA_CRAWLER_API_KEY
+#   ALGOLIA_CRAWLER_ID
+
+[build]
+command = "yarn run build && yarn algolia:reindex"
+publish = "build"
+
+# ===========================================
 # CRITICAL REDIRECTS (High Traffic Pages)
 # ===========================================
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
+    "algolia:reindex": "node scripts/algolia-reindex.mjs",
+    "algolia:sync-config": "node scripts/sync-algolia-config.mjs",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",

--- a/scripts/algolia-reindex.mjs
+++ b/scripts/algolia-reindex.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Triggers a re-crawl of the Algolia DocSearch crawler after a Netlify build.
+ *
+ * Runs only on production deploys. Skips silently for deploy previews,
+ * branch deploys, and local builds. Skips with a warning if credentials
+ * are missing instead of failing the build.
+ *
+ * Required environment variables (set in Netlify → Site settings → Environment):
+ *   ALGOLIA_CRAWLER_USER_ID
+ *   ALGOLIA_CRAWLER_API_KEY
+ *   ALGOLIA_CRAWLER_ID            (the crawler UUID, currently 7ecdfe3f-744f-4633-9dd4-bc7c721b383b)
+ */
+
+const CONTEXT = process.env.CONTEXT ?? "local";
+const USER_ID = process.env.ALGOLIA_CRAWLER_USER_ID;
+const API_KEY = process.env.ALGOLIA_CRAWLER_API_KEY;
+const CRAWLER_ID = process.env.ALGOLIA_CRAWLER_ID;
+
+if (CONTEXT !== "production") {
+  console.log(`[algolia-reindex] Skipping: CONTEXT=${CONTEXT} (production only).`);
+  process.exit(0);
+}
+
+if (!USER_ID || !API_KEY || !CRAWLER_ID) {
+  console.warn(
+    "[algolia-reindex] Skipping: missing ALGOLIA_CRAWLER_USER_ID / " +
+      "ALGOLIA_CRAWLER_API_KEY / ALGOLIA_CRAWLER_ID. Set them in Netlify env."
+  );
+  process.exit(0);
+}
+
+const auth = Buffer.from(`${USER_ID}:${API_KEY}`).toString("base64");
+const url = `https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/reindex`;
+
+try {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { Authorization: `Basic ${auth}` },
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.error(
+      `[algolia-reindex] Failed: ${res.status} ${res.statusText}\n${body}`
+    );
+    // Don't fail the deploy. Search staleness is not a build blocker.
+    process.exit(0);
+  }
+
+  console.log("[algolia-reindex] Reindex triggered successfully.");
+} catch (err) {
+  console.error("[algolia-reindex] Network error:", err.message);
+  process.exit(0);
+}

--- a/scripts/sync-algolia-config.mjs
+++ b/scripts/sync-algolia-config.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Pushes config/algolia-config.js up to the Algolia DocSearch crawler so the
+ * dashboard config matches what's in the repo. Run manually after editing the
+ * crawler config in this repo:
+ *
+ *   ALGOLIA_CRAWLER_USER_ID=... \
+ *   ALGOLIA_CRAWLER_API_KEY=... \
+ *   ALGOLIA_CRAWLER_ID=7ecdfe3f-744f-4633-9dd4-bc7c721b383b \
+ *     node scripts/sync-algolia-config.mjs
+ *
+ * Pass --dry-run to print the JSON payload without sending it.
+ */
+
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const USER_ID = process.env.ALGOLIA_CRAWLER_USER_ID;
+const API_KEY = process.env.ALGOLIA_CRAWLER_API_KEY;
+const CRAWLER_ID = process.env.ALGOLIA_CRAWLER_ID;
+const DRY_RUN = process.argv.includes("--dry-run");
+
+if (!USER_ID || !API_KEY || !CRAWLER_ID) {
+  console.error(
+    "Missing required env: ALGOLIA_CRAWLER_USER_ID, ALGOLIA_CRAWLER_API_KEY, ALGOLIA_CRAWLER_ID"
+  );
+  process.exit(1);
+}
+
+const configPath = resolve(__dirname, "../config/algolia-config.js");
+const local = require(configPath);
+
+// Convert the local config to the Crawler API shape:
+//   - top-level appId/apiKey stay
+//   - any `recordExtractor` function gets serialized as { __type, source }
+// Notes on intentionally omitted fields:
+//   - `externalUrlRegex`: rejected by the API as a forbidden field. URL
+//     boundaries are enforced via `pathsToMatch` and `discoveryPatterns`.
+//   - `appId` / `apiKey`: the local file holds the public *search* key used
+//     by the docs frontend, not the *write* key the crawler needs to index.
+//     The crawler already has the correct write key configured in the
+//     dashboard. Leave it untouched.
+const payload = {
+  rateLimit: local.rateLimit,
+  maxDepth: local.maxDepth,
+  startUrls: local.startUrls,
+  sitemaps: local.sitemaps,
+  discoveryPatterns: local.discoveryPatterns,
+  initialIndexSettings: local.initialIndexSettings,
+  actions: (local.actions ?? []).map((action) => ({
+    ...action,
+    recordExtractor:
+      typeof action.recordExtractor === "function"
+        ? { __type: "function", source: action.recordExtractor.toString() }
+        : action.recordExtractor,
+  })),
+};
+
+if (DRY_RUN) {
+  console.log(JSON.stringify(payload, null, 2));
+  process.exit(0);
+}
+
+const auth = Buffer.from(`${USER_ID}:${API_KEY}`).toString("base64");
+const url = `https://crawler.algolia.com/api/1/crawlers/${CRAWLER_ID}/config`;
+
+const res = await fetch(url, {
+  method: "PATCH",
+  headers: {
+    Authorization: `Basic ${auth}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify(payload),
+});
+
+const body = await res.text();
+
+if (!res.ok) {
+  console.error(`Failed: ${res.status} ${res.statusText}\n${body}`);
+  process.exit(1);
+}
+
+console.log("Crawler config synced successfully.");
+console.log(body);

--- a/src/pages/404.module.css
+++ b/src/pages/404.module.css
@@ -1,0 +1,86 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6rem 1.5rem;
+  min-height: 60vh;
+}
+
+.inner {
+  max-width: 720px;
+  width: 100%;
+  text-align: left;
+}
+
+.code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, "Cascadia Mono", monospace;
+  font-size: 1rem;
+  letter-spacing: 0.15em;
+  color: var(--ifm-color-emphasis-600);
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+}
+
+.title {
+  font-size: 2.25rem;
+  line-height: 1.2;
+  margin: 0 0 1rem;
+}
+
+.subtitle {
+  font-size: 1.05rem;
+  color: var(--ifm-color-emphasis-700);
+  margin-bottom: 2.5rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 2.5rem;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .list {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.item {
+  margin: 0;
+}
+
+.itemLink {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.itemLink:hover {
+  border-color: var(--ifm-color-primary);
+  text-decoration: none;
+  transform: translateY(-1px);
+}
+
+.itemLabel {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.itemDescription {
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.footer {
+  font-size: 0.95rem;
+  color: var(--ifm-color-emphasis-700);
+}

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import Link from "@docusaurus/Link";
+import Layout from "@theme/Layout";
+import styles from "./404.module.css";
+
+const SUGGESTIONS: Array<{ label: string; description: string; to: string }> = [
+  {
+    label: "Get Started",
+    description: "Install Suites and write your first test.",
+    to: "/docs/get-started/",
+  },
+  {
+    label: "Quickstart",
+    description: "A minimal end-to-end example.",
+    to: "/docs/get-started/quickstart",
+  },
+  {
+    label: "Guides",
+    description: "Solitary, sociable, test doubles, and fundamentals.",
+    to: "/docs/guides/",
+  },
+  {
+    label: "API Reference",
+    description: "TestBed, Mock, and configuration APIs.",
+    to: "/docs/api-reference/",
+  },
+  {
+    label: "Migrating from Automock",
+    description: "Move an existing Automock setup to Suites.",
+    to: "/docs/migration-guides/from-automock",
+  },
+];
+
+export default function NotFound(): React.ReactElement {
+  return (
+    <Layout
+      title="Page not found"
+      description="The page you are looking for does not exist."
+    >
+      <main className={styles.container}>
+        <div className={styles.inner}>
+          <p className={styles.code}>404</p>
+          <h1 className={styles.title}>This page took an early return.</h1>
+          <p className={styles.subtitle}>
+            We may have moved or renamed it during the recent docs refresh.
+            Try one of these instead:
+          </p>
+
+          <ul className={styles.list}>
+            {SUGGESTIONS.map((item) => (
+              <li key={item.to} className={styles.item}>
+                <Link to={item.to} className={styles.itemLink}>
+                  <span className={styles.itemLabel}>{item.label}</span>
+                  <span className={styles.itemDescription}>{item.description}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          <p className={styles.footer}>
+            Still stuck? <Link to="/">Go to the homepage</Link> or{" "}
+            <Link href="https://github.com/suites-dev/suites/issues">
+              open an issue on GitHub
+            </Link>
+            .
+          </p>
+        </div>
+      </main>
+    </Layout>
+  );
+}

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,41 @@
+# Suites
+
+> Suites is a unit testing framework for TypeScript backends working with inversion of control and dependency injection. It generates mocks for class dependencies and provides a virtual test container that mirrors your real DI container, so you can write solitary or sociable unit tests with minimal boilerplate.
+
+Suites supports NestJS and InversifyJS, integrates with Jest, Sinon, and Vitest, and offers a migration path from Automock.
+
+## Get started
+
+- [Get Started overview](https://suites.dev/docs/get-started/): entry point for new users
+- [Why Suites](https://suites.dev/docs/get-started/why-suites): the problem Suites solves and how it differs from manual mocking
+- [Installation](https://suites.dev/docs/get-started/installation): install the right packages for your DI framework and test runner
+- [Quickstart](https://suites.dev/docs/get-started/quickstart): a minimal end-to-end example
+
+## Guides
+
+- [Guides overview](https://suites.dev/docs/guides/): index of conceptual and how-to guides
+- [Fundamentals](https://suites.dev/docs/guides/fundamentals): core concepts and the testing model
+- [Solitary tests](https://suites.dev/docs/guides/solitary): isolating a single class with auto-generated mocks
+- [Sociable tests](https://suites.dev/docs/guides/sociable): testing a class together with selected real collaborators
+- [Test doubles](https://suites.dev/docs/guides/test-doubles): mocks, stubs, and spies in Suites
+- [Virtual test container](https://suites.dev/docs/guides/virtual-test-container): how Suites builds an isolated DI graph for each test
+
+## API reference
+
+- [API Reference index](https://suites.dev/docs/api-reference/)
+- [TestBed (solitary)](https://suites.dev/docs/api-reference/testbed-solitary)
+- [TestBed (sociable)](https://suites.dev/docs/api-reference/testbed-sociable)
+- [Mock](https://suites.dev/docs/api-reference/mock)
+- [Mock configuration](https://suites.dev/docs/api-reference/mock-configuration)
+- [Unit reference](https://suites.dev/docs/api-reference/unit-reference)
+- [Types](https://suites.dev/docs/api-reference/types)
+
+## Migration
+
+- [Migrating from Automock](https://suites.dev/docs/migration-guides/from-automock)
+
+## Project
+
+- [Changelog](https://suites.dev/docs/changelog)
+- [GitHub repository](https://github.com/suites-dev/suites)
+- [Examples repository](https://github.com/suites-dev/examples)

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,71 @@
+# Default: allow crawling
 User-agent: *
 Allow: /
+
+# ===========================================
+# Search engines: explicitly allowed
+# ===========================================
+User-agent: Googlebot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: DuckDuckBot
+Allow: /
+
+# ===========================================
+# AI crawlers: explicitly allowed so Suites
+# shows up in AI-generated answers.
+# ===========================================
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+# ===========================================
+# SEO scrapers: blocked.
+# They consume bandwidth, skew analytics,
+# and provide no discovery value to us.
+# ===========================================
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+User-agent: BLEXBot
+Disallow: /
+
+User-agent: DataForSeoBot
+Disallow: /
+
+User-agent: serpstatbot
+Disallow: /
 
 Sitemap: https://suites.dev/sitemap.xml


### PR DESCRIPTION
## Summary

A combined SEO + tooling pass on the docs site, plus a Netlify-side automation so the search index never drifts behind a deploy again.

The work was scoped using GSC data (last 6 months) and the full GA4 export. Two pages had clear search-intent mismatches and were rewritten; one page (the migration guide) was missing the codemod CTA and had stale version numbers; a few infra holes (no `editUrl`, no custom 404, no `llms.txt`, weak `robots.txt`, manual Algolia reindex) are closed.

## Content changes

### `docs/guides/test-doubles.md`
Page is currently sitting on ~8k impressions/quarter at position ~7 with a 0.16% CTR. Search Console queries showed Google was ranking it for Martin Fowler / textbook test-double explainer queries, but the page opened with Suites-specific phrasing so visitors didn't recognize it as relevant.

- New title and H1 lead with the searched term
- Definition table covering Stub / Mock / Spy / Fake at the top
- Outbound citations to Fowler's *Mocks Aren't Stubs* and Meszaros's *xUnit Test Patterns*
- Quickstart CTA inside the article body
- Existing "How Suites Uses..." section onward is unchanged

### `docs/migration-guides/from-automock.md`
- New `:::tip` block at the top recommending `@suites/codemod` with copy-paste `--dry` and apply commands
- Reframed manual steps as "what the codemod does" for users who want to migrate by hand or understand specifics
- Install block restructured by stack (NestJS+Jest, NestJS+Vitest, NestJS+Sinon, Inversify+Sinon)
- Stale `2.1.0` version references corrected to `2.1.2` (latest published Automock)
- New section: **"Looking for old Automock internals?"** with a symbol-mapping table for `TestbedBuilder`, `ClassCtorReflector`, `class-props-reflector`, `packages/core/src/services/testbed-builder.ts`, etc. Addresses ~250 search impressions/6mo of devs hitting broken imports
- Includes `@automock/core` alongside `@automock/jest` and `@automock/sinon`

### `docs/changelog.md`
Em dash cleanup in three lines.

## SEO / discovery infra

- **`static/llms.txt`** (new): tells AI crawlers which docs to read first. Linked top-level entry points by section.
- **`static/robots.txt`** (rewritten): explicit allow list for Googlebot, Bingbot, DuckDuckBot, GPTBot, ClaudeBot, OAI-SearchBot, ChatGPT-User, PerplexityBot, Google-Extended. Explicit block list for AhrefsBot, SemrushBot, MJ12bot, DotBot, PetalBot, BLEXBot, DataForSeoBot, serpstatbot.
- **`docusaurus.config.ts`**: enable `editUrl` on the docs preset so every page gets an "Edit this page" link to GitHub.
- **`src/pages/404.tsx`** + **`404.module.css`** (new): branded 404 page with five high-intent recovery links and a GitHub issues fallback. Recovers traffic that lands on URLs not covered by the existing 155-line redirects map.

## Build and tooling

- **`scripts/algolia-reindex.mjs`** (new): POSTs to the Algolia DocSearch crawler reindex endpoint. Gated on `CONTEXT=production`, so deploy previews and branch deploys are no-ops. Missing credentials log a warning and exit 0 instead of failing the build.
- **`scripts/sync-algolia-config.mjs`** (new): pushes `config/algolia-config.js` up to the crawler dashboard (PATCH `/crawlers/{id}/config`). Supports `--dry-run`. Use this whenever you edit the local Algolia config so the dashboard stops drifting.
- **`netlify.toml`**: new `[build]` section running `yarn run build && yarn algolia:reindex`.
- **`package.json`**: two new scripts, `algolia:reindex` and `algolia:sync-config`.
- **`.gitignore`**: `.netlify/` (added automatically by `netlify link`).

## Required Netlify env vars (already set)

`ALGOLIA_CRAWLER_USER_ID`, `ALGOLIA_CRAWLER_ID` (all contexts), and `ALGOLIA_CRAWLER_API_KEY` (production / deploy-preview / branch-deploy, marked secret) are configured on the site. Reindex will fire automatically on the first production deploy of this branch.

## Test plan

- [ ] Netlify deploy preview builds successfully (no breakage from the new `[build]` command on PR previews; reindex script logs `Skipping: CONTEXT=deploy-preview`)
- [ ] Visit `/docs/guides/test-doubles/` on the preview and confirm new title, table, and Quickstart CTA render correctly
- [ ] Visit `/docs/migration-guides/from-automock` on the preview and confirm the codemod tip block, install variants, and internals table render
- [ ] Visit any docs page and confirm the "Edit this page" link appears at the bottom and points to `github.com/suites-dev/docs.suites.dev/edit/master/...`
- [ ] Visit `<preview-url>/llms.txt` and confirm it returns the file
- [ ] Visit `<preview-url>/robots.txt` and confirm the new bot rules are present
- [ ] Visit a fake URL (e.g. `<preview-url>/docs/this-does-not-exist`) and confirm the new 404 page renders with recovery links
- [ ] After merge to master, watch the production deploy logs for `[algolia-reindex] Reindex triggered successfully.`
- [ ] After deploy, confirm the index is fresh by searching for newly-rewritten test-doubles content via the docs search bar

## Follow-ups (not in this PR)

- Consider `npm deprecate @automock/jest @automock/sinon @automock/core` so installs surface a warning pointing at the migration guide
- Sociable content depth: comparison page (`solitary vs sociable`), more examples, internal links to `/docs/guides/sociable`
- Mobile title audit on the next 5 highest-impression docs pages
- Custom 404 design polish if needed (currently uses Docusaurus theme variables for a clean dark-mode look)