### PR TITLE
docs: update installation guide for 3.1.0 release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,24 +10,6 @@ All notable changes to Suites are documented here. For the complete version hist
 
 ---
 
-## May 2026
-
-### 🔧 v3.1.0
-
-This release focuses on build correctness and compatibility with modern TypeScript and testing tooling.
-
-**What's Fixed:**
-
-- ✅ **ESM build**: All packages now ship a working ESM output (`dist/esm/`) with proper `.js` extensions on relative imports. The previous build used `moduleResolution: "node"`, which omits extensions and caused ESM consumers to fail silently. Each package now uses `moduleResolution: NodeNext` per-format tsconfig.
-- ✅ **NodeNext type resolution**: Users with `moduleResolution: NodeNext` or `"type": "module"` projects were receiving `StubbedInstance<T>` instead of `Mocked<T>` from `unitRef.get()` because the ESM entry point failed to load. The corrected ESM build resolves this, and `unitRef.get()` now returns the right `Mocked<T>` type.
-- ✅ **Vitest 4.x compatibility**: Vitest 4.x made mock function properties (`mock`, `lastCall`, etc.) getter-only (non-writable). The Proxy `set` trap in `@suites/doubles.vitest` now guards against non-writable, non-configurable properties, fixing a `TypeError: Cannot set property lastCall` crash.
-
-**Minimum Node version updated to 18.** Node 16 reached end-of-life and is no longer supported.
-
-[View full release notes →](https://github.com/suites-dev/suites/releases/tag/v3.1.0)
-
----
-
 ## January 2, 2025
 
 ### 🐛 Bug Fixes in v3.0.1
@@ -124,8 +106,7 @@ The transition to Suites represented a rebranding and modernization while preser
 
 | Version           | Status                 | Released  | Support Until |
 |-------------------|------------------------|-----------|---------------|
-| `v3.1.x`          | 🟢 Stable              | May 2026  | TBD           |
-| `v3.0.x`          | 🔧 Maintenance         | July 2024 | TBD           |
+| `v3.0.x`          | 🟢 Stable              | July 2024 | June 2026     |
 | `v2.x` (Automock) | ⚠️ Critical fixes only | Nov 2022  | June 2025     |
 
 **Support Policy:**

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,24 @@ All notable changes to Suites are documented here. For the complete version hist
 
 ---
 
+## May 2026
+
+### 🔧 v3.1.0
+
+This release focuses on build correctness and compatibility with modern TypeScript and testing tooling.
+
+**What's Fixed:**
+
+- ✅ **ESM build**: All packages now ship a working ESM output (`dist/esm/`) with proper `.js` extensions on relative imports. The previous build used `moduleResolution: "node"`, which omits extensions and caused ESM consumers to fail silently. Each package now uses `moduleResolution: NodeNext` per-format tsconfig.
+- ✅ **NodeNext type resolution**: Users with `moduleResolution: NodeNext` or `"type": "module"` projects were receiving `StubbedInstance<T>` instead of `Mocked<T>` from `unitRef.get()` because the ESM entry point failed to load. The corrected ESM build resolves this, and `unitRef.get()` now returns the right `Mocked<T>` type.
+- ✅ **Vitest 4.x compatibility**: Vitest 4.x made mock function properties (`mock`, `lastCall`, etc.) getter-only (non-writable). The Proxy `set` trap in `@suites/doubles.vitest` now guards against non-writable, non-configurable properties, fixing a `TypeError: Cannot set property lastCall` crash.
+
+**Minimum Node version updated to 18.** Node 16 reached end-of-life and is no longer supported.
+
+[View full release notes →](https://github.com/suites-dev/suites/releases/tag/v3.1.0)
+
+---
+
 ## January 2, 2025
 
 ### 🐛 Bug Fixes in v3.0.1
@@ -106,7 +124,8 @@ The transition to Suites represented a rebranding and modernization while preser
 
 | Version           | Status                 | Released  | Support Until |
 |-------------------|------------------------|-----------|---------------|
-| `v3.0.x`          | 🟢 Stable              | July 2024 | June 2026     |
+| `v3.1.x`          | 🟢 Stable              | May 2026  | TBD           |
+| `v3.0.x`          | 🔧 Maintenance         | July 2024 | TBD           |
 | `v2.x` (Automock) | ⚠️ Critical fixes only | Nov 2022  | June 2025     |
 
 **Support Policy:**

--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -110,7 +110,7 @@ This configuration is necessary for Suites to reflect class dependencies and con
 ```
 
 :::note NodeNext / ESM projects
-As of `3.1.0`, Suites ships a working ESM build with full `.js` extension support. Projects using `moduleResolution: NodeNext` or `"type": "module"` are fully supported without workarounds.
+As of `3.1.0`, projects configured with `moduleResolution: NodeNext` or `"type": "module"` work with Suites out of the box. No additional configuration is required beyond the standard setup shown above.
 :::
 
 ## Type Reference Configuration

--- a/docs/get-started/installation.mdx
+++ b/docs/get-started/installation.mdx
@@ -13,7 +13,7 @@ Get Suites up and running in your project.
 
 ## Prerequisites
 
-- Node 16 or higher
+- Node 18 or higher
 - TypeScript project with decorators enabled
 - A framework implementing IoC ([NestJS](https://nestjs.com/), [InversifyJS](https://inversify.io/)), or plain
 TypeScript classes (manually)
@@ -109,6 +109,10 @@ This configuration is necessary for Suites to reflect class dependencies and con
 }
 ```
 
+:::note NodeNext / ESM projects
+As of `3.1.0`, Suites ships a working ESM build with full `.js` extension support. Projects using `moduleResolution: NodeNext` or `"type": "module"` are fully supported without workarounds.
+:::
+
 ## Type Reference Configuration
 
 To ensure type safety and maintain a clean API, Suites requires setting up type references for your mocking library. This approach enables importing all utilities from `@suites/unit` while maintaining proper type information.
@@ -182,9 +186,18 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: { globals: true, root: './' },
-  plugins: [swc.vite({ module: { type: 'es6' } })],
+  plugins: [
+    swc.vite({
+      module: { type: 'es6' },
+      jsc: { transform: { decoratorMetadata: true } },
+    }),
+  ],
 });
 ```
+
+:::note Vitest 4.x
+Vitest 4.x uses Oxc by default instead of esbuild. The `esbuild: false` option is a no-op in Vitest 4.x and produces a warning; remove it from any existing config. The configuration above works correctly with both Vitest 3.x and 4.x. Vitest 4.x is supported as of `3.1.0`.
+:::
 
 <div class="next-steps-section">
 ## What's Next?


### PR DESCRIPTION
## Summary

- Updated Node.js prerequisite from 16 to 18
- Added NodeNext callout: as of 3.1.0, projects using `moduleResolution: NodeNext` or `"type": "module"` work out of the box
- Updated Vitest config example for 4.x (`jsc.transform.decoratorMetadata: true`, note about `esbuild: false` no-op)

## Test plan

- [ ] Preview URL renders installation page correctly
- [ ] NodeNext callout is visible and accurate
- [ ] Vitest 4.x config snippet is correct